### PR TITLE
fix(config): Add CheckInterval to toml file for registry

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -8,6 +8,7 @@ Protocol = 'http'
 StartupMsg = 'device llrp started'
 Timeout = 5000
 ConnectRetries = 10
+CheckInterval = '10s'
 Labels = []
 EnableAsyncReadings = true
 AsyncBufferSize = 16


### PR DESCRIPTION
fixes #36 

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## Issue Number:
https://github.com/edgexfoundry/device-rfid-llrp-go/issues/36

## What is the new behavior?
Adds `CheckInterval` of 10 seconds to toml file.

## Does this PR introduce a breaking change?

- [X] No

## New Imports
- [X] No

## Other information
Thanks @tonyespy and @lenny-intel 