### PR TITLE
fix: invalid boolean logic in UpdateDevice code

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -656,7 +656,7 @@ func (d *Driver) UpdateDevice(deviceName string, protocols protocolMap, adminSta
 	var isNew bool
 	dev, isNew, err = d.getDevice(deviceName, protocols)
 	// No need to call update if the device was just created.
-	if !(err == nil && isNew) {
+	if isNew || err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Closes #33 

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Device IP/Port changes, but service does not attempt to connect using new info.

## Issue Number:
https://github.com/edgexfoundry/device-rfid-llrp-go/issues/33

## What is the new behavior?
Device IP and Port are updated and a new connection is established:

    level=INFO ts=2021-06-24T18:59:33.565052025Z app=edgex-device-rfid-llrp source=discover.go:427 msg="Discovered device: &{deviceName:SpeedwayR-11-25-D6 host:10.0.0.53 port:5093 vendor:25882 model:2001002}"
    level=INFO ts=2021-06-24T18:59:33.565216561Z app=edgex-device-rfid-llrp source=discover.go:235 oldInfo="map[host:10.0.0.53 port:5092]" discoveredInfo="&{deviceName:SpeedwayR-11-25-D6 host:10.0.0.53 port:5093 vendor:25882 model:2001002}" msg="Existing device has been discovered with a different network address."
    level=DEBUG ts=2021-06-24T18:59:33.565275015Z app=edgex-device-rfid-llrp source=manageddevices.go:127 msg="Updating managed Device: : SpeedwayR-11-25-D6\n"
    level=INFO ts=2021-06-24T18:59:33.57958692Z app=edgex-device-rfid-llrp source=device.go:119 msg="Updated device: SpeedwayR-11-25-D6"
    level=DEBUG ts=2021-06-24T18:59:50.643802737Z app=edgex-device-rfid-llrp source=driver.go:639 msg="Updating device: SpeedwayR-11-25-D6 protocols: map[metadata:map[model:2001002 vendorPEN:25882] tcp:map[host:10.0.0.53 port:5093]] adminState: UNLOCKED"
    level=DEBUG ts=2021-06-24T19:00:22.594371624Z app=edgex-device-rfid-llrp source=logging.go:32 type=MsgKeepAlive device=SpeedwayR-10-EF-18 msg="Incoming LLRP message"
    level=DEBUG ts=2021-06-24T19:00:23.000925592Z app=edgex-device-rfid-llrp source=logging.go:45 type=MsgKeepAlive device=SpeedwayR-10-EF-18 msg="Handled LLRP message."


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->
- [X] No

