### PR TITLE
fix: use provision watcher logic for discovered devices

### DIFF
--- a/internal/driver/discover_test.go
+++ b/internal/driver/discover_test.go
@@ -194,12 +194,21 @@ func TestAutoDiscoverNaming(t *testing.T) {
 			if discovered[0].Name != test.name {
 				t.Errorf("expected discovered device's name to be %s, but was: %s", test.name, discovered[0].Name)
 			}
-			pen, ok := discovered[0].Protocols["tcp"]["vendorPEN"]
+
+			pen, ok := discovered[0].Protocols["metadata"]["vendorPEN"]
 			if !ok {
-				t.Fatalf("Missing vendorPEN field in tcp protocol. ProtocolMap: %+v", discovered[0].Protocols)
+				t.Fatalf("Missing vendorPEN field in metadata protocol. ProtocolMap: %+v", discovered[0].Protocols)
 			}
 			if pen != strconv.FormatUint(uint64(test.caps.DeviceManufacturer), 10) {
 				t.Errorf("expected vendorPEN to be %v, but was: %s", test.caps.DeviceManufacturer, pen)
+			}
+
+			fw, ok := discovered[0].Protocols["metadata"]["fwVersion"]
+			if !ok {
+				t.Fatalf("Missing fwVersion field in metadata protocol. ProtocolMap: %+v", discovered[0].Protocols)
+			}
+			if fw != test.caps.FirmwareVersion {
+				t.Errorf("expected fwVersion to be %v, but was: %s", test.caps.FirmwareVersion, fw)
 			}
 		})
 	}

--- a/internal/driver/types.go
+++ b/internal/driver/types.go
@@ -39,6 +39,6 @@ func (imt ImpinjModelType) HostnamePrefix() string {
 	case XArray, XArrayEAP, XArrayWM:
 		return "xArray"
 	default:
-		return DefaultDevicePrefix
+		return defaultDevicePrefix
 	}
 }


### PR DESCRIPTION
Closes #39 

Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What is the current behavior?
A workaround for adding devices directly to core-metadata due to legacy bugs in EdgeX's `device-sdk-go`.

## Issue Number:
https://github.com/edgexfoundry/device-rfid-llrp-go/issues/39

## What is the new behavior?
Use the updated provision watcher code provided in EdgeX Hanoi.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [X] No
