### PR TITLE
fix(snap): stage curl for auto-configure

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -130,8 +130,6 @@ parts:
   auto-configure:
     plugin: dump
     source: bin/
-    stage:
-      - bin/auto-configure.sh
     organize:
       auto-configure.sh: bin/auto-configure.sh
     stage-packages:


### PR DESCRIPTION
The stage filter was only staging the auto-configure script. Removing it will allow staging everything, including the curl package.

Fixes https://github.com/edgexfoundry/device-rfid-llrp-go/issues/87

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
```
$ snap remove edgex-device-rfid-llrp edgexfoundry
edgex-device-rfid-llrp removed
edgexfoundry removed
 
$ snap install edgexfoundry --edge
edgexfoundry (edge) 2.2.1-dev.2 from Canonical✓ installed

$ snap install edgex-device-rfid-llrp --channel=edge/pr-86
edgex-device-rfid-llrp (edge/pr-86) 2.1.0-dev.15 from Canonical✓ installed

$ snap start edgex-device-rfid-llrp.device-rfid-llrp 
Started.
  
$ sudo snap connect edgex-device-rfid-llrp:network-control 
$ sudo snap connect edgex-device-rfid-llrp:network-observe

$ sudo cat /var/snap/edgexfoundry/current/secrets/consul-acl-token/bootstrap_token.json | jq -r '.SecretID' | tee consul-token.txt
62eb8e9f-66ee-d64a-ddf6-bcbd181cb75f

$ edgex-device-rfid-llrp.auto-configure $(cat consul-token.txt)
Dependencies Check: Success
      Consul Check: Success
        Interfaces: wlp3s0 
           Subnets: 192.168.0.0/24
         Configure: Success
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->