### PR TITLE
fix: Correctly set versions of service and SDK when building binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,18 @@ MICROSERVICES=cmd/device-rfid-llrp
 
 .PHONY: $(MICROSERVICES)
 
+# This pulls the version of the SDK from the go.mod file. It works by looking for the line
+# with the SDK and printing just the version number that comes after it.
+SDKVERSION=$(shell sed -En 's|.*github.com/edgexfoundry/device-sdk-go/v2 (v[\.0-9a-zA-Z-]+).*|\1|p' go.mod)
+
+# this pulls the version from local VERSION file that is created by the Jenkins Pipeline.
 VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 
 GIT_SHA=$(shell git rev-parse HEAD)
-GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-rfid-llrp.Version=$(VERSION)"
-CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.SDKVersion=$(SDKVERSION) \
-					-X github.com/edgexfoundry/app-functions-sdk-go/v2/internal.ApplicationVersion=$(APPVERSION) \
-					-X edgexfoundry/app-rfid-llrp-inventory.Version=$(APPVERSION)" -trimpath -mod=readonly -buildmode=pie
+CGOFLAGS=-ldflags "-linkmode=external \
+				   -X github.com/edgexfoundry/device-sdk-go/v2/internal/common.SDKVersion=$(SDKVERSION) \
+				   -X github.com/edgexfoundry/device-rfid-llrp-go.Version=$(VERSION)" \
+				   -trimpath -mod=readonly -buildmode=pie
 
 build: $(MICROSERVICES)
 


### PR DESCRIPTION
fixes #88

signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Start non-secure edgex stack
Create ./VERSION file locally with "2.2.0" as the contents
Build this branch
Run these service locally
Hit localhost:59989/api/v2/version
Verify it returns the following:
```
{
    "apiVersion": "v2",
    "version": "2.1.0",
    "serviceName": "device-rfid-llrp",
    "sdk_version": "v2.2.0"
}
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->