### PR TITLE
feat!: Remove ZeroMQ MessageBus capability

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -189,9 +189,6 @@ https://github.com/mattn/go-colorable/blob/master/LICENSE
 github.com/mattn/go-isatty (MIT) https://github.com/mattn/go-isatty
 https://github.com/mattn/go-isatty/blob/master/LICENSE
 
-pebbe/zmq4 (BSD-2) https://github.com/pebbe/zmq4
-https://github.com/pebbe/zmq4/blob/master/LICENSE.txt
-
 pmezard/go-difflib (Unspecified) https://github.com/pmezard/go-difflib
 https://github.com/pmezard/go-difflib/blob/master/LICENSE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ FROM ${BASE} AS builder
 
 ARG ADD_BUILD_TAGS=""
 ARG MAKE="make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build"
-ARG ALPINE_PKG_BASE="make git gcc libc-dev zeromq-dev"
+ARG ALPINE_PKG_BASE="make git"
 ARG ALPINE_PKG_EXTRA=""
 
 RUN apk add --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
@@ -37,7 +37,7 @@ FROM alpine:3.16
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2022: Intel'
 
-RUN apk add --update --no-cache zeromq dumb-init
+RUN apk add --update --no-cache dumb-init
 
 COPY --from=builder /app/LICENSE /
 COPY --from=builder /app/Attribution.txt /

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,5 @@
 .PHONY: build test unittest lint clean prepare update docker
 
-GO=CGO_ENABLED=1 GO111MODULE=on go
-
-# see https://shibumi.dev/posts/hardening-executables
-CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-CGO_CFLAGS="-O2 -pipe -fno-plt"
-CGO_CXXFLAGS="-O2 -pipe -fno-plt"
-CGO_LDFLAGS="-Wl,-O1,–sort-common,–as-needed,-z,relro,-z,now"
-
 ARCH=$(shell uname -m)
 
 MICROSERVICES=cmd/device-rfid-llrp
@@ -22,10 +14,7 @@ SDKVERSION=$(shell sed -En 's|.*github.com/edgexfoundry/device-sdk-go/v3 (v[\.0-
 VERSION=$(shell cat ./VERSION 2>/dev/null || echo 0.0.0)
 
 GIT_SHA=$(shell git rev-parse HEAD)
-CGOFLAGS=-ldflags "-linkmode=external \
-				   -X github.com/edgexfoundry/device-sdk-go/v3/internal/common.SDKVersion=$(SDKVERSION) \
-				   -X github.com/edgexfoundry/device-rfid-llrp-go.Version=$(VERSION)" \
-				   -trimpath -mod=readonly -buildmode=pie
+GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-rfid-llrp-go.Version=$(VERSION)" -trimpath -mod=readonly
 
 build: $(MICROSERVICES)
 
@@ -36,17 +25,17 @@ tidy:
 	go mod tidy
 
 cmd/device-rfid-llrp:
-	$(GO) build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
+	CGO_ENABLED=0 go build -tags "$(ADD_BUILD_TAGS)" $(GOFLAGS) -o $@ ./cmd
 
 unittest:
-	$(GO) test ./... -coverprofile=coverage.out ./...
+	go test ./... -coverprofile=coverage.out ./...
 
 lint:
 	@which golangci-lint >/dev/null || echo "WARNING: go linter not installed. To install, run\n  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$$(go env GOPATH)/bin v1.46.2"
 	@if [ "z${ARCH}" = "zx86_64" ] && which golangci-lint >/dev/null ; then golangci-lint run --config .golangci.yml ; else echo "WARNING: Linting skipped (not on x86_64 or linter not installed)"; fi
 
 test: unittest lint
-	$(GO) vet ./...
+	go vet ./...
 	gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")
 	[ "`gofmt -l $$(find . -type f -name '*.go'| grep -v "/vendor/")`" = "" ]
 	./bin/test-attribution-txt.sh
@@ -68,4 +57,4 @@ docker-nats:
 	make -e ADD_BUILD_TAGS=include_nats_messaging docker
 
 vendor:
-	go mod vendor
+	CGO_ENABLED=0 go mod vendor

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-rfid-llrp-go
 go 1.18
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5
+	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5 h1:8jvPXdI06yGOH3qw3BgN/xutHVoAgUU+Q946rc89C9w=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.5/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6 h1:4hvEOdtLUjWBqvc9ZpdYLqLhrXzZRwW86RsgWJBmSkQ=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.6/go.mod h1:9tfeovR5aXyNb4/kB6ymWvwFUYABvjt9vy3UPyEN6qg=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5 h1:3WMWQ0oi++KFrau/e8BOTqgzORCa3G7bLG0w/wO72Io=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.5/go.mod h1:cGXMUtbbzw+npJpMcFHPlXIN+ZPF71aiimhJ6v8kaSc=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.2 h1:xp5MsP+qf/fuJxy8fT7k1N+c4j4C6w04qMCBXm6id7o=

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,8 +75,7 @@ parts:
     after: [metadata]
     source: .
     plugin: make
-    build-packages: [git, libzmq3-dev, pkg-config]
-    stage-packages: [libzmq5]
+    build-packages: [git, pkg-config]
     build-snaps:
       - go/1.18/stable
     override-build: |


### PR DESCRIPTION
BREAKING CHANGE: ZeroMQ MessageBus capability no longer available

Signed-off-by: Marc-Philippe Fuller <marc-philippe.fuller@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
`make docker`
`make build`
Run service locally with non-secure EdgeX stack running.
Verify bootstraps successfully

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->