### PR TITLE
fix(snap): Refactor to avoid conflicts with readonly config provider directory

### DIFF
--- a/snap/local/bin/source-env-file.sh
+++ b/snap/local/bin/source-env-file.sh
@@ -1,17 +1,5 @@
 #!/bin/bash -e
 
-EDGEX_STARTUP_DURATION=$(snapctl get startup-duration)
-
-if [ -n "$EDGEX_STARTUP_DURATION" ]; then
-  export EDGEX_STARTUP_DURATION
-fi
-
-EDGEX_STARTUP_INTERVAL=$(snapctl get startup-interval)
-
-if [ -n "$EDGEX_STARTUP_INTERVAL" ]; then
-  export EDGEX_STARTUP_INTERVAL
-fi
-
 # convert cmdline to string array
 ARGV=($@)
 
@@ -20,14 +8,14 @@ BINPATH="${ARGV[0]}"
 
 # binary name == service name/key
 SERVICE=$(basename "$BINPATH")
-ENV_FILE="$SNAP_DATA/config/$SERVICE/res/$SERVICE.env"
+ENV_FILE="$SNAP_DATA/config/$SERVICE/overrides.env"
 TAG="edgex-$SERVICE."$(basename "$0")
 
 if [ -f "$ENV_FILE" ]; then
     logger --tag=$TAG "sourcing $ENV_FILE"
     set -o allexport
     source "$ENV_FILE" set
-    set +o allexport 
+    set +o allexport
 fi
 
 exec "$@"

--- a/snap/local/helper-go/go.mod
+++ b/snap/local/helper-go/go.mod
@@ -2,4 +2,4 @@ module github.com/edgexfoundry/device-rfid-llrp/snap/local/helper-go
 
 go 1.20
 
-require github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab
+require github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0

--- a/snap/local/helper-go/go.sum
+++ b/snap/local/helper-go/go.sum
@@ -1,6 +1,6 @@
-github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab h1:wpiKN0hX8tqeZNa4jPvgyrqP8ixm1Xu7lcQA3bypR7w=
-github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230112170125-c0580fb68dab/go.mod h1:RvJ48YbdBPZn7L8OcylOpKIlIJD+nMjo5D7WSnPYusY=
+github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0 h1:h2C5W3mEC5g/s9W/mwh7X/3uSqKjNln/xHP41i8Mw/M=
+github.com/canonical/edgex-snap-hooks/v3 v3.0.0-20230315153603-544c6823a1b0/go.mod h1:qGZwprCZGZk2pA9BrleUtSrGrfHIaIz1356p8aqzuN4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/snap/local/helper-go/install.go
+++ b/snap/local/helper-go/install.go
@@ -20,6 +20,7 @@ import (
 	hooks "github.com/canonical/edgex-snap-hooks/v3"
 	"github.com/canonical/edgex-snap-hooks/v3/env"
 	"github.com/canonical/edgex-snap-hooks/v3/log"
+	"github.com/canonical/edgex-snap-hooks/v3/snapctl"
 )
 
 // installConfig copies all config files from $SNAP to $SNAP_DATA
@@ -32,7 +33,14 @@ func installConfig() error {
 func install() {
 	log.SetComponentName("install")
 
-	if err := installConfig(); err != nil {
-		log.Fatalf("Error installing config files: %s", err)
+	// Install default config files only if no config provider is connected
+	isConnected, err := snapctl.IsConnected(app + "-config").Run()
+	if err != nil {
+		log.Fatalf("Error checking interface connection: %s", err)
+	}
+	if !isConnected {
+		if err := installConfig(); err != nil {
+			log.Fatalf("Error installing config files: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
This PR makes changes to incorporate the following fixes:
- https://github.com/canonical/edgex-snap-hooks/pull/83
- https://github.com/canonical/edgex-snap-hooks/pull/82

Additionally, the following changes have been made:
- remove deprecated `startup-duration` and `startup-interval` options

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
For testing instructions, please refer to https://github.com/edgexfoundry/device-mqtt-go/pull/535

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->