### PR TITLE
refactor: Consume latest SDK and adjust for breaking change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/device-rfid-llrp-go
 go 1.20
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.86
+	github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.88
 	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.41
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.86 h1:/KlsgMaC/cMdAFuUlpQkT77Lhwcj93F6oUCU+69Uly4=
-github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.86/go.mod h1:aAN9czOZdRONjqZHFvBfjH167abSQ1oMnhX/cwFroRQ=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.88 h1:coB/SnFuBj5pmAfxoBstE9ZtPLpOVjI1m5oBqw7DDUo=
+github.com/edgexfoundry/device-sdk-go/v3 v3.0.0-dev.88/go.mod h1:aAN9czOZdRONjqZHFvBfjH167abSQ1oMnhX/cwFroRQ=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.87 h1:6HstzqNY+wocvvJpy1Zt1MyRK9gQZUhYzG1W/rr70CM=
 github.com/edgexfoundry/go-mod-bootstrap/v3 v3.0.0-dev.87/go.mod h1:/l9+zh+pthpA/wv/Y4ZROWfNLk5R3G27t/2yJHO2s/g=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.10 h1:iDuAO3vpBQnlQuFhai/NATbJkiYXxo3bPCtSnFl07Yw=

--- a/internal/driver/device.go
+++ b/internal/driver/device.go
@@ -192,7 +192,7 @@ func (d *Driver) NewLLRPDevice(name string, address net.Addr, opState contract.O
 
 				if isEnabled {
 					d.lc.Warn("Failed to connect to Device after multiple tries.", "device", name)
-					if err := d.svc.SetDeviceOpState(name, contract.Down); err != nil {
+					if err := d.svc.UpdateDeviceOperatingState(name, contract.Down); err != nil {
 						d.lc.Error("Failed to set device operating state to Disabled.",
 							"device", name, "error", err.Error())
 						// This is not likely, but might as well try again next round.
@@ -465,7 +465,7 @@ func (l *LLRPDevice) onConnect(svc interfaces.DeviceServiceSDK) {
 
 	if !isEnabled {
 		l.lc.Info("Device connection restored.", "device", l.name)
-		if err := svc.SetDeviceOpState(l.name, contract.Up); err != nil {
+		if err := svc.UpdateDeviceOperatingState(l.name, contract.Up); err != nil {
 			l.lc.Error("Failed to set device operating state to Enabled.",
 				"device", l.name, "error", err.Error())
 		} else {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A*
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX
Make and run the service from this branch
verify it builds and starts w/o errors

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->