### PR TITLE
fix: Move intializion of registered llrp devices from initialize to start

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -137,6 +137,10 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 		return errors.Wrap(err, "failed to listen to custom config changes")
 	}
 
+	return nil
+}
+
+func (d *Driver) Start() error {
 	registered := d.svc.Devices()
 	d.devicesMu.Lock()
 	defer d.devicesMu.Unlock()
@@ -156,10 +160,6 @@ func (d *Driver) Initialize(sdk interfaces.DeviceServiceSDK) error {
 		d.activeDevices[device.Name] = d.NewLLRPDevice(device.Name, addr, device.OperatingState)
 	}
 
-	return nil
-}
-
-func (d *Driver) Start() error {
 	return nil
 }
 


### PR DESCRIPTION
fixes: #235

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-rfid-llrp-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)NA
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)NA
  <link to docs PR>

## Testing Instructions
Start Simulator
Start service
Restart the service
verify that there is no error or panic

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->