### PR TITLE
ci: add automated release workflow on tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Create Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - '!v*-dev*'
+jobs:
+  release:
+    uses: edgexfoundry/edgex-global-pipelines/.github/workflows/release.yml@stable
+    permissions:
+      contents: write


### PR DESCRIPTION
New release workflow that will create GitHub releases when semantic version tags are pushed.